### PR TITLE
fix: validate settings before publish

### DIFF
--- a/.changeset/sharp-falcons-leap.md
+++ b/.changeset/sharp-falcons-leap.md
@@ -2,4 +2,4 @@
 "flowershow": patch
 ---
 
-Validate the plugin's settings before every publish attempt. `validateSettings` was already implemented and tested but never wired up — users with an empty token or site name would hit the network and see a generic 401 in the console. Now the publish entry points (single-note, publish-all, and every modal action) bail out early with the specific "you need to define a Flowershow PAT Token" / "you need to define a Site Name" notice.
+Validate the plugin's settings before every publish attempt. `validateSettings` was already implemented and tested but never wired up — users with an empty token or site name would hit the network and see a generic 401 in the console. Now the publish entry points (single-note, publish-all, and every modal action) bail out early and surface the specific configuration notice (missing/invalid PAT token or missing site name) instead of failing on the network.

--- a/.changeset/sharp-falcons-leap.md
+++ b/.changeset/sharp-falcons-leap.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Validate the plugin's settings before every publish attempt. `validateSettings` was already implemented and tested but never wired up — users with an empty token or site name would hit the network and see a generic 401 in the console. Now the publish entry points (single-note, publish-all, and every modal action) bail out early with the specific "you need to define a Flowershow PAT Token" / "you need to define a Site Name" notice.

--- a/main.ts
+++ b/main.ts
@@ -14,6 +14,7 @@ import Publisher from "src/Publisher";
 import SettingView from "src/SettingView";
 import { DEFAULT_SETTINGS, type IFlowershowSettings } from "src/settings";
 import { createSiteNotice, FlowershowError } from "src/utils";
+import { validateSettings } from "src/utils/publisherHelpers";
 
 export default class Flowershow extends Plugin {
 	private startupAnalytics: string[] = [];
@@ -110,6 +111,7 @@ export default class Flowershow extends Plugin {
 	/** Publish single note and its embeds */
 	// TODO make sure that embeds in frontmatter are published too!
 	async publishSingleNote() {
+		if (!validateSettings(this.settings)) return;
 		try {
 			const currentFile = this.app.workspace.getActiveFile();
 			if (!currentFile) {
@@ -144,6 +146,7 @@ export default class Flowershow extends Plugin {
 
 	// Publish new or changed files, and unpublish deleted files
 	async publishAllFiles() {
+		if (!validateSettings(this.settings)) return;
 		try {
 			const { changedFiles, deletedFiles, newFiles } =
 				await this.publisher.getPublishStatus();

--- a/src/components/PublishStatusModal.tsx
+++ b/src/components/PublishStatusModal.tsx
@@ -28,6 +28,7 @@ import {
 } from "@mui/x-tree-view/TreeItem";
 import { Box } from "@mui/material";
 import { FlowershowError } from "src/utils";
+import { validateSettings } from "src/utils/publisherHelpers";
 
 interface PublishStatusModalProps {
 	app: App;
@@ -282,6 +283,7 @@ interface PublishStatusModalContentProps extends PublishStatusModalProps {
 
 const PublishStatusModalContent: React.FC<PublishStatusModalContentProps> = ({
 	publisher,
+	settings,
 	onClose,
 	initialStatus,
 	initialSiteId,
@@ -352,6 +354,7 @@ const PublishStatusModalContent: React.FC<PublishStatusModalContentProps> = ({
 		operation: "publish" | "unpublish",
 		action: () => Promise<{ siteUrl: string; filesPublished: number }>
 	) => {
+		if (!validateSettings(settings)) return;
 		setIsPublishing(true);
 		try {
 			const result = await action();


### PR DESCRIPTION
validateSettings was implemented and fully tested in src/utils/publisherHelpers.ts but never called from production. Users with an empty token, missing site name, or wrong-prefixed token went straight to the network and saw a generic 401 in the Notice/console instead of the specific actionable message.

Wire it into all three publish entry points:

- main.ts: publishSingleNote and publishAllFiles
- src/components/PublishStatusModal.tsx: handlePublishOperation, which covers every action button in the modal including "Publish All"

validateSettings already calls new Notice(...) internally with the specific reason, so the call sites just need to bail out on false. The "settings" prop was already on the modal's interface; it's now also destructured in PublishStatusModalContent.
