### PR TITLE
test(publisher): pin the SHA-matches-upload invariant

### DIFF
--- a/.changeset/lucky-mountains-rise.md
+++ b/.changeset/lucky-mountains-rise.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Add tests for the SHA-matches-upload invariant in `Publisher.publishBatch`. The pure-helper layer in `publisherHelpers.ts` has been heavily tested, but the orchestrator that uses those helpers had no coverage. New tests pin: (a) the SHA submitted to `publishFiles` matches the bytes uploaded to R2, (b) `rootDir` path normalization and content rewriting are applied consistently to both surfaces, and (c) the deletion path normalizes paths through `rootDir`. The `obsidian` mock gains a `Notice.setMessage`/`hide` stub and the vitest config substitutes the build-time env vars so the production code under test compiles.

--- a/src/Publisher.test.ts
+++ b/src/Publisher.test.ts
@@ -25,6 +25,10 @@ const baseSettings = (overrides: Partial<IFlowershowSettings> = {}): IFlowershow
   ...overrides,
 });
 
+// Obsidian's TFile.stat.size is a byte count; string.length is UTF-16 code
+// units. Encode so fixtures stay accurate for non-ASCII content.
+const byteSize = (s: string): number => new TextEncoder().encode(s).length;
+
 interface FakeFile {
   path: string;
   extension: string;
@@ -43,7 +47,7 @@ function makeApp(files: FakeFile[]): App {
           ({
             path: f.path,
             extension: f.extension,
-            stat: { size: f.content.length },
+            stat: { size: byteSize(f.content) },
           }) as TFile,
       ),
   };
@@ -105,7 +109,7 @@ function makeTFile(file: FakeFile): TFile {
   return {
     path: file.path,
     extension: file.extension,
-    stat: { size: file.content.length },
+    stat: { size: byteSize(file.content) },
   } as TFile;
 }
 

--- a/src/Publisher.test.ts
+++ b/src/Publisher.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import Publisher from "./Publisher";
+import type { IFlowershowSettings } from "./settings";
+import { calculateTextSha } from "./utils";
+
+/**
+ * The load-bearing invariant in Publisher.publishBatch: the SHA submitted to
+ * the server (via client.publishFiles) must hash exactly the bytes that the
+ * client subsequently PUTs to R2 (via client.uploadToR2). If the two diverge
+ * — for example because rewriteRootDirPaths was applied to one but not the
+ * other — the server will reject the upload as a hash mismatch.
+ *
+ * These tests pin that invariant by running publishBatch against a stubbed
+ * FlowershowClient that captures both the submitted metadata and the actual
+ * upload bytes, then re-hashes the upload bytes and asserts equality.
+ */
+
+const baseSettings = (overrides: Partial<IFlowershowSettings> = {}): IFlowershowSettings => ({
+  flowershowToken: "fs_pat_test",
+  siteName: "test-site",
+  rootDir: "",
+  excludePatterns: [],
+  lastSeenVersion: "",
+  ...overrides,
+});
+
+interface FakeFile {
+  path: string;
+  extension: string;
+  content: string;
+}
+
+function makeApp(files: FakeFile[]): App {
+  const byPath = new Map(files.map((f) => [f.path, f]));
+  const vault = {
+    cachedRead: vi.fn(async (file: TFile) => byPath.get(file.path)!.content),
+    readBinary: vi.fn(async () => new ArrayBuffer(0)),
+    getName: () => "test-vault",
+    getFiles: () =>
+      files.map(
+        (f) =>
+          ({
+            path: f.path,
+            extension: f.extension,
+            stat: { size: f.content.length },
+          }) as TFile,
+      ),
+  };
+  const metadataCache = { getCache: () => null };
+  return { vault, metadataCache } as unknown as App;
+}
+
+interface ClientStub {
+  publishCalls: { siteId: string; files: { path: string; sha: string }[] }[];
+  uploadCalls: { uploadUrl: string; bytes: Uint8Array; contentType: string }[];
+}
+
+function stubClient(publisher: Publisher): ClientStub {
+  const stub: ClientStub = { publishCalls: [], uploadCalls: [] };
+  // biome-ignore lint/suspicious/noExplicitAny: replacing private field for testing
+  (publisher as any).client = {
+    getUserInfo: async () => ({ username: "tester" }),
+    getSiteByName: async () => ({
+      site: {
+        id: "site-id",
+        projectName: "test-site",
+        url: "https://example.com",
+        userId: "tester",
+        createdAt: "",
+      },
+    }),
+    publishFiles: async (
+      siteId: string,
+      files: { path: string; sha: string }[],
+    ) => {
+      stub.publishCalls.push({ siteId, files });
+      return {
+        files: files.map((f) => ({
+          path: f.path,
+          uploadUrl: `https://r2.example.com/${f.path}`,
+          blobId: `blob-${f.path}`,
+          contentType: "text/markdown",
+        })),
+      };
+    },
+    uploadToR2: async (
+      uploadUrl: string,
+      content: ArrayBuffer | Uint8Array,
+      contentType: string,
+    ) => {
+      const bytes =
+        content instanceof Uint8Array
+          ? new Uint8Array(content)
+          : new Uint8Array(content);
+      stub.uploadCalls.push({ uploadUrl, bytes, contentType });
+      return true;
+    },
+    deleteFiles: vi.fn(async () => ({ deleted: [], notFound: [] })),
+  };
+  return stub;
+}
+
+function makeTFile(file: FakeFile): TFile {
+  return {
+    path: file.path,
+    extension: file.extension,
+    stat: { size: file.content.length },
+  } as TFile;
+}
+
+describe("Publisher.publishBatch SHA / upload invariant", () => {
+  it("submits a SHA that matches the bytes uploaded to R2 (no rootDir)", async () => {
+    const file: FakeFile = { path: "note.md", extension: "md", content: "Hello world" };
+    const app = makeApp([file]);
+    const publisher = new Publisher(app, baseSettings());
+    const stub = stubClient(publisher);
+
+    await publisher.publishBatch({ filesToPublish: [makeTFile(file)] });
+
+    expect(stub.publishCalls).toHaveLength(1);
+    expect(stub.uploadCalls).toHaveLength(1);
+
+    const submittedSha = stub.publishCalls[0].files[0].sha;
+    const uploadedSha = await calculateTextSha(
+      new TextDecoder().decode(stub.uploadCalls[0].bytes),
+    );
+    expect(submittedSha).toBe(uploadedSha);
+  });
+
+  it("strips the rootDir prefix from the submitted path and applies the rewriter consistently", async () => {
+    const file: FakeFile = {
+      path: "Public/Recipes/bread.md",
+      extension: "md",
+      content: "See [[Public/Other/topic]] for more.",
+    };
+    const app = makeApp([file]);
+    const publisher = new Publisher(app, baseSettings({ rootDir: "Public" }));
+    const stub = stubClient(publisher);
+
+    await publisher.publishBatch({ filesToPublish: [makeTFile(file)] });
+
+    // Submitted path has rootDir stripped
+    expect(stub.publishCalls[0].files[0].path).toBe("Recipes/bread.md");
+
+    // Uploaded bytes have the wikilink rewritten too
+    const uploadedText = new TextDecoder().decode(stub.uploadCalls[0].bytes);
+    expect(uploadedText).toBe("See [[Other/topic]] for more.");
+
+    // And the SHA still matches
+    const submittedSha = stub.publishCalls[0].files[0].sha;
+    const uploadedSha = await calculateTextSha(uploadedText);
+    expect(submittedSha).toBe(uploadedSha);
+  });
+
+  it("publishes multiple files and matches each submitted SHA to its upload", async () => {
+    const files: FakeFile[] = [
+      { path: "a.md", extension: "md", content: "alpha" },
+      { path: "b.md", extension: "md", content: "beta beta beta" },
+      { path: "c.md", extension: "md", content: "gamma\nwith newlines\n" },
+    ];
+    const app = makeApp(files);
+    const publisher = new Publisher(app, baseSettings());
+    const stub = stubClient(publisher);
+
+    await publisher.publishBatch({
+      filesToPublish: files.map(makeTFile),
+    });
+
+    expect(stub.publishCalls[0].files).toHaveLength(3);
+    expect(stub.uploadCalls).toHaveLength(3);
+
+    for (const upload of stub.uploadCalls) {
+      const matchingSubmission = stub.publishCalls[0].files.find(
+        (f) => upload.uploadUrl.endsWith(f.path),
+      );
+      expect(matchingSubmission).toBeDefined();
+      const uploadedSha = await calculateTextSha(
+        new TextDecoder().decode(upload.bytes),
+      );
+      expect(matchingSubmission!.sha).toBe(uploadedSha);
+    }
+  });
+});
+
+describe("Publisher.publishBatch deletion path", () => {
+  it("normalizes deletion paths through rootDir", async () => {
+    const app = makeApp([]);
+    const publisher = new Publisher(app, baseSettings({ rootDir: "Public" }));
+    const stub = stubClient(publisher);
+    let deleteCall: { siteId: string; paths: string[] } | null = null;
+    // biome-ignore lint/suspicious/noExplicitAny: replacing private field for testing
+    (publisher as any).client.deleteFiles = vi.fn(
+      async (siteId: string, paths: string[]) => {
+        deleteCall = { siteId, paths };
+        return { deleted: paths, notFound: [] };
+      },
+    );
+
+    await publisher.publishBatch({
+      filesToDelete: ["Public/Recipes/bread.md", "Public/Other/topic.md"],
+    });
+
+    expect(deleteCall).not.toBeNull();
+    expect(deleteCall!.paths).toEqual([
+      "Recipes/bread.md",
+      "Other/topic.md",
+    ]);
+    expect(stub.publishCalls).toHaveLength(0);
+    expect(stub.uploadCalls).toHaveLength(0);
+  });
+});

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -5,6 +5,10 @@ export class Notice {
   constructor(message: string, duration?: number) {
     // Mock implementation - do nothing in tests
   }
+  setMessage(_message: string) {
+    return this;
+  }
+  hide() {}
 }
 
 export class Modal {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,4 +12,12 @@ export default defineConfig({
       obsidian: path.resolve(__dirname, "src/__mocks__/obsidian.ts"),
     },
   },
+  // esbuild replaces these at build time; vitest needs the same substitution
+  // so modules that read process.env.FLOWERSHOW_API_URL at load time work.
+  define: {
+    "process.env.FLOWERSHOW_API_URL": JSON.stringify(
+      "https://test.flowershow.app",
+    ),
+    "process.env.FLOWERSHOW_PLUGIN_VERSION": JSON.stringify("test"),
+  },
 });


### PR DESCRIPTION
The pure-helper layer in publisherHelpers.ts has 116 tests. The orchestrator that USES those helpers had zero — including the load-bearing invariant that the SHA submitted to publishFiles must hash the same bytes that are subsequently PUT to R2. If those diverge (e.g. because rewriteRootDirPaths runs on one but not the other), the server rejects the upload as a hash mismatch.

New file src/Publisher.test.ts:

- "submits a SHA that matches the bytes uploaded to R2 (no rootDir)"
- "strips the rootDir prefix from the submitted path and applies the rewriter consistently"
- "publishes multiple files and matches each submitted SHA to its upload"
- "normalizes deletion paths through rootDir"

Each test stubs out FlowershowClient via a private-field override, captures both the submitted metadata and the actual upload bytes, then re-hashes the upload bytes and asserts equality.

Two small support changes:

- src/__mocks__/obsidian.ts: Notice now has stub setMessage and hide methods so Publisher's progress Notice doesn't blow up under test.
- vitest.config.ts: substitute FLOWERSHOW_API_URL and FLOWERSHOW_PLUGIN_VERSION at vitest time the same way esbuild does at build time, so settings.ts module-load doesn't see undefined.

120 tests pass (was 116).
