### PR TITLE
perf: cache rewritten text within a publish batch

### DIFF
--- a/.changeset/swift-eagles-glide.md
+++ b/.changeset/swift-eagles-glide.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Cache rewritten text content within a publish batch. `Publisher.publishBatch` used to run the `rootDir` rewriter chain twice per text file — once for SHA computation, once for the R2 upload bytes. A small per-call `Map<string, string>` now memoizes the result so each text file is rewritten once, halving the regex work during a batch publish. The cache also enforces the invariant that the SHA submitted to the server matches the bytes uploaded, since both reads come from the same rewriter pass.

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -197,6 +197,9 @@ export default class Publisher {
         // Prepare file metadata for selected files only
         const fileMetadata: FileMetadata[] = [];
         const filesToProcess = opts.filesToPublish;
+        // Cache rewritten text per file path so the SHA we submit and the
+        // bytes we upload come from the same rewriter pass.
+        const textCache = new Map<string, string>();
 
         for (const file of filesToProcess) {
           const normalizedPath = normalizePath(
@@ -208,6 +211,7 @@ export default class Publisher {
           let sha: string;
           if (isPlainTextExtension(file.extension)) {
             const text = await this.getTextContent(file);
+            textCache.set(file.path, text);
             sha = await calculateTextSha(text);
           } else {
             const bytes = await this.app.vault.readBinary(file);
@@ -237,7 +241,8 @@ export default class Publisher {
 
           let content: ArrayBuffer | Uint8Array;
           if (isPlainTextExtension(file.extension)) {
-            const text = await this.getTextContent(file);
+            const text =
+              textCache.get(file.path) ?? (await this.getTextContent(file));
             content = new TextEncoder().encode(text);
           } else {
             const bytes = await this.app.vault.readBinary(file);


### PR DESCRIPTION
Publisher.publishBatch was running the rootDir rewriter chain twice per text file — once for SHA computation, once again for the upload bytes. For a vault with hundreds of text files and a rootDir set, that's hundreds of duplicate regex passes per batch.

Add a per-call Map<path, string> in publishBatch that memoizes the rewritten content during the SHA loop; the upload loop reads from it. For files whose path doesn't end up in publishResult.files (server already has the same SHA), the cache entry is simply unused. For files that do upload, the regex chain runs once instead of twice.

Beyond the speedup, this enforces a real invariant: the SHA submitted to publishFiles and the bytes uploaded to R2 are now guaranteed to come from the same rewriter pass. Before, they were two independent passes that just happened to produce identical output.

All 116 vitest cases unchanged.