### PR TITLE
ci: run type-check and tests on PR and push to main

### DIFF
--- a/.changeset/brave-rivers-listen.md
+++ b/.changeset/brave-rivers-listen.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Add a CI workflow that runs type-check and tests on every pull request and push to `main`. Uses the project's existing tooling (npm, tsc, vitest); doesn't introduce new tools. Biome is intentionally left out for now since the existing codebase has pre-existing findings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Build, lint, type-check, test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Type check
+        run: npx tsc -noEmit -skipLibCheck
+
+      - name: Tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   check:
-    name: Build, lint, type-check, test
+    name: Type check and test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,12 +22,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22.x"
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Type check
-        run: npx tsc -noEmit -skipLibCheck
+        run: npx tsc --noEmit --skipLibCheck
 
       - name: Tests
         run: npm test


### PR DESCRIPTION
Add .github/workflows/ci.yml that runs on every pull request and push to main:

- npm install
- npx tsc -noEmit -skipLibCheck
- npm test

Uses the project's existing tooling (npm, tsc, vitest) — no new tools introduced. Biome is intentionally left out; the existing codebase has pre-existing diagnostics that would block every PR, and adopting that as a CI gate is a maintainer decision rather than a contributor one.

Node 22 to match release.yml. Concurrency is configured to cancel in-progress runs only for pull_request, so push-to-main runs are not interrupted by subsequent PR-triggered runs.