### PR TITLE
fix: strip rootDir prefix from canvas paths on publish

### DIFF
--- a/.changeset/canvas-rootdir-paths.md
+++ b/.changeset/canvas-rootdir-paths.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Fix broken canvas images when publishing from a subfolder. Canvas (`.canvas`) files are now rewritten on publish so their `file`/`text` node references drop the configured rootDir prefix, matching the stripped blob keys the plugin already uploads. Previously canvas files uploaded as raw binary and kept the prefix, so published canvases pointed at paths that 404'd.

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -12,6 +12,7 @@ import {
   shouldSkipFile,
   validatePublishFrontmatter,
   rewriteRootDirPaths,
+  rewriteCanvasPaths,
 } from "./utils/publisherHelpers";
 
 export interface PublishStatus {
@@ -89,8 +90,21 @@ export default class Publisher {
     );
   }
 
+  /**
+   * Files whose contents we read, rewrite, and upload as UTF-8 text (rather than
+   * raw bytes). Beyond the plain-text formats, `.canvas` files are JSON that we
+   * must rewrite so their internal `file`/`text` references drop the rootDir
+   * prefix — otherwise the published canvas points at blob keys that don't exist.
+   */
+  private isTextFile(file: TFile): boolean {
+    return isPlainTextExtension(file.extension) || file.extension === "canvas";
+  }
+
   private async getTextContent(file: TFile): Promise<string> {
     const text = await this.app.vault.cachedRead(file);
+    if (file.extension === "canvas") {
+      return rewriteCanvasPaths(text, this.settings.rootDir);
+    }
     return rewriteRootDirPaths(text, this.settings.rootDir);
   }
 
@@ -283,7 +297,7 @@ export default class Publisher {
 
           // Calculate SHA
           let sha: string;
-          if (isPlainTextExtension(file.extension)) {
+          if (this.isTextFile(file)) {
             const text = await this.getTextContent(file);
             sha = await calculateTextSha(text);
           } else {
@@ -313,7 +327,7 @@ export default class Publisher {
           if (!file) continue;
 
           let content: ArrayBuffer | Uint8Array;
-          if (isPlainTextExtension(file.extension)) {
+          if (this.isTextFile(file)) {
             const text = await this.getTextContent(file);
             content = new TextEncoder().encode(text);
           } else {
@@ -427,7 +441,7 @@ export default class Publisher {
         const normalizedPath = normalizePath(file.path, this.settings.rootDir);
 
         let sha: string;
-        if (isPlainTextExtension(file.extension)) {
+        if (this.isTextFile(file)) {
           const text = await this.getTextContent(file);
           sha = await calculateTextSha(text);
         } else {

--- a/src/utils/publisherHelpers.test.ts
+++ b/src/utils/publisherHelpers.test.ts
@@ -13,6 +13,7 @@ import {
   rewriteBaseQueryPaths,
   rewriteFrontmatterPaths,
   rewriteRootDirPaths,
+  rewriteCanvasPaths,
 } from "./publisherHelpers";
 import { IFlowershowSettings } from "src/settings";
 import { App, TFile } from "obsidian";
@@ -791,5 +792,83 @@ describe("rewriteRootDirPaths", () => {
     ].join("\n");
 
     expect(rewriteRootDirPaths(content, "Public")).toBe(expected);
+  });
+});
+
+describe("rewriteCanvasPaths", () => {
+  it("returns content unchanged when no rootDir", () => {
+    const content = JSON.stringify({
+      nodes: [{ id: "a", type: "file", file: "Public/img.png" }],
+    });
+    expect(rewriteCanvasPaths(content, "")).toBe(content);
+  });
+
+  it("strips rootDir prefix from file node paths", () => {
+    const content = JSON.stringify({
+      nodes: [{ id: "a", type: "file", file: "Public/Pasted image.png" }],
+      edges: [],
+    });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result.nodes[0].file).toBe("Pasted image.png");
+  });
+
+  it("strips rootDir prefix from nested file node paths", () => {
+    const content = JSON.stringify({
+      nodes: [{ id: "a", type: "file", file: "Public/Assets/photo.jpg" }],
+    });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result.nodes[0].file).toBe("Assets/photo.jpg");
+  });
+
+  it("leaves file paths outside rootDir untouched", () => {
+    const content = JSON.stringify({
+      nodes: [{ id: "a", type: "file", file: "Other/img.png" }],
+    });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result.nodes[0].file).toBe("Other/img.png");
+  });
+
+  it("does not strip a mere prefix match that isn't a path segment", () => {
+    const content = JSON.stringify({
+      nodes: [{ id: "a", type: "file", file: "PublicArchive/img.png" }],
+    });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result.nodes[0].file).toBe("PublicArchive/img.png");
+  });
+
+  it("rewrites rootDir paths inside text node markdown", () => {
+    const content = JSON.stringify({
+      nodes: [{ id: "a", type: "text", text: "![[Public/img.png]] [[Public/note]]" }],
+    });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result.nodes[0].text).toBe("![[img.png]] [[note]]");
+  });
+
+  it("handles a mix of node types", () => {
+    const content = JSON.stringify({
+      nodes: [
+        { id: "a", type: "file", file: "Public/img.png" },
+        { id: "b", type: "text", text: "see ![[Public/note.md]]" },
+        { id: "c", type: "link", url: "https://example.com/Public/x" },
+        { id: "d", type: "group", label: "Public" },
+      ],
+    });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result.nodes[0].file).toBe("img.png");
+    expect(result.nodes[1].text).toBe("see ![[note.md]]");
+    // Non-path fields are left alone.
+    expect(result.nodes[2].url).toBe("https://example.com/Public/x");
+    expect(result.nodes[3].label).toBe("Public");
+  });
+
+  it("returns content unchanged when JSON is invalid", () => {
+    const content = "{ not valid json";
+    expect(rewriteCanvasPaths(content, "Public")).toBe(content);
+  });
+
+  it("tolerates missing or non-array nodes", () => {
+    const content = JSON.stringify({ edges: [] });
+    const result = JSON.parse(rewriteCanvasPaths(content, "Public"));
+    expect(result).toEqual({ edges: [] });
   });
 });

--- a/src/utils/publisherHelpers.ts
+++ b/src/utils/publisherHelpers.ts
@@ -228,6 +228,41 @@ export function rewriteRootDirPaths(content: string, rootDir: string): string {
   return result;
 }
 
+/**
+ * Rewrite rootDir-prefixed paths inside a JSON Canvas file.
+ */
+export function rewriteCanvasPaths(content: string, rootDir: string): string {
+  if (!rootDir) return content;
+  const root = normalizeRootDir(rootDir);
+
+  let data: unknown;
+  try {
+    data = JSON.parse(content);
+  } catch {
+    return content;
+  }
+
+  if (
+    !data ||
+    typeof data !== "object" ||
+    !Array.isArray((data as { nodes?: unknown }).nodes)
+  ) {
+    return content;
+  }
+
+  const nodes = (data as { nodes: Array<Record<string, unknown>> }).nodes;
+  for (const node of nodes) {
+    if (!node || typeof node !== "object") continue;
+    if (node.type === "file" && typeof node.file === "string") {
+      node.file = stripRootDirPrefix(node.file, root);
+    } else if (node.type === "text" && typeof node.text === "string") {
+      node.text = rewriteRootDirPaths(node.text, rootDir);
+    }
+  }
+
+  return JSON.stringify(data, null, "\t");
+}
+
 export function rewriteBaseQueryPaths(content: string, rootDir: string): string {
   if (!rootDir) return content;
   const root = normalizeRootDir(rootDir);


### PR DESCRIPTION
## Problem

Images (and embeds) on Obsidian **Canvas** pages break on Flowershow sites published from a **subfolder** (plugin `rootDir` set, e.g. `Publish`).

When publishing from a subfolder the plugin strips the rootDir prefix from upload keys and from markdown content (frontmatter, wikilinks, embeds, links, base queries). **Canvas files were the one uncovered case:**

1. `.canvas` isn't a plain-text extension, so canvas files uploaded as raw binary (`readBinary`) and never passed through the rewriters at all.
2. Even if they had, the rewriters only understand markdown/frontmatter syntax, not JSON Canvas `file`/`text` node references.

Result: the canvas's internal `node.file` kept the `Publish/` prefix while the stored blob key had it stripped → the page rendered `<img src="/Publish/Pasted image ….png">`, which 404s. Markdown embeds worked because they *were* rewritten.

Confirmed on a live site: the blob exists at the stripped path (`…/raw/Pasted image ….png` → 200) but the canvas requests it with the stale `Publish/` prefix (404).

## Fix

- Add `rewriteCanvasPaths(content, rootDir)` in `publisherHelpers.ts`: parse the JSON Canvas, strip the rootDir prefix from every `file` node's `file` field, and run the existing markdown rewriters over every `text` node body. Invalid/unexpected JSON is returned untouched so a malformed canvas is never corrupted.
- Wire it into `Publisher`: `getTextContent` dispatches canvas → `rewriteCanvasPaths`, and a new `isTextFile()` predicate makes `.canvas` files read/hash/upload as rewritten UTF-8 text instead of raw binary. (Deliberately **not** added to `isPlainTextExtension`, so canvas JSON never goes through the markdown rewriter.)
- 9 new tests in `publisherHelpers.test.ts`.

## Scope / caveat

This fixes **future** publishes only. Sites already published broken need a re-publish to heal. A renderer-side basename fallback was considered to heal existing sites without a re-publish but deliberately skipped to keep this a single-repo change.

## Verification

- `npm test` → **130 tests pass**
- `npm run build` (tsc + esbuild) → clean

https://claude.ai/code/session_01DEFw5mDet1SNrZN659TtVV